### PR TITLE
Change to ibpsa modelica master.

### DIFF
--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR $HOME
 
 RUN git clone https://github.com/ibpsa/modelica-ibpsa.git $HOME/git/ibpsa/modelica-ibpsa && \
     git clone https://github.com/lbl-srg/modelica-buildings.git $HOME/git/buildings/modelica-buildings && \
-    cd $HOME/git/ibpsa/modelica-ibpsa && git checkout 9e1f57c && \
+    cd $HOME/git/ibpsa/modelica-ibpsa && \
     cd $HOME/git/buildings/modelica-buildings && git checkout 1a6d3a768cf43f43b4e434997653734f85f722d8
 
 RUN python -m pip install --user pandas==0.22.0 requests


### PR DESCRIPTION
Uses ibpsa-modelica master since signal exchange block was merged in https://github.com/ibpsa/modelica-ibpsa/pull/1170.