### PR TITLE
Store data as numpy arrays

### DIFF
--- a/restapi.py
+++ b/restapi.py
@@ -110,6 +110,15 @@ class Results(Resource):
     def get(self):
         '''GET request to receive measurement data.'''
         Y = case.get_results()
+        y_lists = {}
+        u_lists = {}
+        # np array to list
+        for key in Y['y']:
+            y_lists[key] = Y['y'].tolist()
+        for key in Y['u']:
+            u_lists[key] = Y['u'].tolist()
+        Y = {'y':y_lists, 'u':u_lists
+             }
         return Y
         
 class KPI(Resource):

--- a/restapi.py
+++ b/restapi.py
@@ -114,12 +114,11 @@ class Results(Resource):
         u_lists = {}
         # np array to list
         for key in Y['y']:
-            y_lists[key] = Y['y'].tolist()
+            y_lists[key] = Y['y'][key].tolist()
         for key in Y['u']:
-            u_lists[key] = Y['u'].tolist()
-        Y = {'y':y_lists, 'u':u_lists
-             }
-        return Y
+            u_lists[key] = Y['u'][key].tolist()
+        Y_lists = {'y':y_lists, 'u':u_lists}
+        return Y_lists
         
 class KPI(Resource):
     '''Interface to test case KPIs.'''

--- a/testcase.py
+++ b/testcase.py
@@ -84,14 +84,14 @@ class TestCase(object):
         '''
     
         # Outputs data
-        self.y = {'time':[]}
+        self.y = {'time':np.array([])}
         for key in self.output_names:
-            self.y[key] = []
+            self.y[key] = np.array([])
         self.y_store = copy.deepcopy(self.y)
         # Inputs data
-        self.u = {'time':[]}
+        self.u = {'time':np.array([])}
         for key in self.input_names:
-            self.u[key] = []        
+            self.u[key] = np.array([])       
         self.u_store = copy.deepcopy(self.u)
                 
     def __simulation(self,start_time,end_time,input_object=None):
@@ -152,12 +152,12 @@ class TestCase(object):
         for key in self.y.keys():
             self.y[key] = res[key][-1]
             if store:
-                self.y_store[key] = self.y_store[key] + res[key].tolist()[1:]
+                self.y_store[key] = np.append(self.y_store[key], res[key][1:])
         
         # Store control inputs
         if store:
             for key in self.u.keys():
-                self.u_store[key] = self.u_store[key] + res[key].tolist()[1:] 
+                self.u_store[key] = np.append(self.u_store[key], res[key][1:]) 
 
     def advance(self,u):
         '''Advances the test case model simulation forward one step.
@@ -349,7 +349,13 @@ class TestCase(object):
         
         '''
         
-        Y = {'y':self.y_store, 'u':self.u_store}
+        y_send = {}
+        u_send = {}
+        for key in self.y_store.keys():
+            y_send[key] = self.y_store[key].tolist()
+        for key in self.u_store.keys():
+            u_send[key] = self.u_store[key].tolist()
+        Y = {'y':y_send, 'u':u_send}
         
         return Y
         

--- a/testcase.py
+++ b/testcase.py
@@ -349,13 +349,7 @@ class TestCase(object):
         
         '''
         
-        y_send = {}
-        u_send = {}
-        for key in self.y_store.keys():
-            y_send[key] = self.y_store[key].tolist()
-        for key in self.u_store.keys():
-            u_send[key] = self.u_store[key].tolist()
-        Y = {'y':y_send, 'u':u_send}
+        Y = {'y':self.y_store, 'u':self.u_store}
         
         return Y
         


### PR DESCRIPTION
This is for #258.  Namely, it:
- Changes ``testcase.u_store`` and ``testcase.y_store`` to use numpy arrays instead of python lists.
- Edits ``restapi.Results`` to convert numpy arrays to lists for transfer over http, since numpy arrays are not json serializable