### PR TITLE
issue 406 spawn simulation support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ USER root
 # Edit pyfmi to event update at start of simulation for ME2
 RUN sed -i "350 i \\\n        if isinstance(self.model, fmi.FMUModelME2):\n            self.model.event_update()" $JMODELICA_HOME/Python/pyfmi/fmi_algorithm_drivers.py
 
+# Install commands for Spawn
+ENV SPAWN_VERSION=0.3.0-8d93151657
+RUN wget https://spawn.s3.amazonaws.com/custom/Spawn-$SPAWN_VERSION-Linux.tar.gz \
+    && tar -xzf Spawn-$SPAWN_VERSION-Linux.tar.gz \
+    && ln -s /Spawn-$SPAWN_VERSION-Linux/bin/spawn-$SPAWN_VERSION /usr/local/bin/
+
 USER developer
 
 WORKDIR $HOME


### PR DESCRIPTION
This is to address #406 to add simulation support for test case FMUs using Spawn, by installing Spawn into the BOPTEST run-time environment docker container.  

This does not address tools/workflows for compiling test case FMUs with Spawn.