### PR TITLE
Update README so building and deploying test case doesn't fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Visit the [BOPTEST Home Page](https://ibpsa.github.io/project1-boptest/) for mor
 ## Quick-Start to Deploy a Test Case
 1) Download this repository.
 2) Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
-3) Build and deploy a test case using the following commands executed in the root directory of this repository and where <testcase_dir_name> is the name of the test case subdirectory located in [/testcases](https://github.com/ibpsa/project1-boptest/tree/master/testcases):
+3) To build and deploy a test case, use the following commands within the root directory of the extracted software:
 
-  * Linux or macOS: ``$ TESTCASE=<testcase_dir_name> docker-compose up``
-  * Windows PowerShell: ``> ($env:TESTCASE="<testcase_directory>") -and (docker-compose up)``
+  * Linux or macOS: `$ TESTCASE=<testcase_name> docker-compose up`
+  * Windows PowerShell: `> ($env:TESTCASE="<testcase_name>") -and (docker-compose up)`
   * A couple notes:
-    * The first time this command is run, the image ``boptest_base`` will be built.  This takes about a minute.  Subsequent usage will use the already-built image and deploy much faster.
-    * If you update your BOPTEST repository, use the command ``docker rmi boptest_base`` to remove the image so it can be re-built with the updated repository upon next deployment.
-    * ``TESTCASE`` is simply an environment variable.  Consistent with use of docker-compose, you may also edit the value of this variable in the ``.env`` file and then use ``docker-compose up``.
+    * Replace `<testcase_name>` with the name of the test case you wish to deploy.
+    * The first time this command is run, the image boptest_base will be built. This takes about a minute. Subsequent usage will use the already-built image and deploy much faster.
+    * If you update your BOPTEST repository, use the command docker rmi boptest_base to remove the image so it can be re-built with the updated repository upon next deployment.
+    * TESTCASE is simply an environment variable. Consistent with use of docker-compose, you may also edit the value of this variable in the `.env` file and then use `docker-compose up`.
 
 4) In a separate process, use the test case API defined below to interact with the test case using your test controller.  Alternatively, view and run an example test controller as described below.
 5) Shutdown the test case by the command ``docker-compose down`` executed in the root directory of this repository

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Visit the [BOPTEST Home Page](https://ibpsa.github.io/project1-boptest/) for mor
   * Windows PowerShell: `> ($env:TESTCASE="<testcase_name>") -and (docker-compose up)`
   * A couple notes:
     * Replace `<testcase_name>` with the name of the test case you wish to deploy.
-    * The first time this command is run, the image boptest_base will be built. This takes about a minute. Subsequent usage will use the already-built image and deploy much faster.
-    * If you update your BOPTEST repository, use the command docker rmi boptest_base to remove the image so it can be re-built with the updated repository upon next deployment.
-    * TESTCASE is simply an environment variable. Consistent with use of docker-compose, you may also edit the value of this variable in the `.env` file and then use `docker-compose up`.
+    * The first time this command is run, the image `boptest_base` will be built. This takes about a minute. Subsequent usage will use the already-built image and deploy much faster.
+    * If you update your BOPTEST repository, use the command `docker rmi boptest_base` to remove the image so it can be re-built with the updated repository upon next deployment.
+    * `TESTCASE` is simply an environment variable. Consistent with use of docker-compose, you may also edit the value of this variable in the `.env` file and then use `docker-compose up`.
 
 4) In a separate process, use the test case API defined below to interact with the test case using your test controller.  Alternatively, view and run an example test controller as described below.
 5) Shutdown the test case by the command ``docker-compose down`` executed in the root directory of this repository

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Visit the [BOPTEST Home Page](https://ibpsa.github.io/project1-boptest/) for mor
   * Linux or macOS: ``$ TESTCASE=<testcase_name> docker-compose up``
   * Windows PowerShell: ``> ($env:TESTCASE="<testcase_name>") -and (docker-compose up)``
   * A couple notes:
-    * Replace ``<testcase_name>`` with the name of the test case you wish to deploy.
+    * Replace ``<testcase_name>`` with the name of the test case you wish to deploy.  Test case names can be found in the ["testcases" directory](https://github.com/ibpsa/project1-boptest/tree/master/testcases) or on the ["Test Cases" web page](https://ibpsa.github.io/project1-boptest/testcases/index.html).
     * The first time this command is run, the image ``boptest_base`` will be built. This takes about a minute. Subsequent usage will use the already-built image and deploy much faster.
     * If you update your BOPTEST repository, use the command ``docker rmi boptest_base`` to remove the image so it can be re-built with the updated repository upon next deployment.
     * ``TESTCASE`` is simply an environment variable. Consistent with use of docker-compose, you may also edit the value of this variable in the ``.env`` file and then use ``docker-compose up``.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Visit the [BOPTEST Home Page](https://ibpsa.github.io/project1-boptest/) for mor
 2) Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
 3) To build and deploy a test case, use the following commands within the root directory of the extracted software:
 
-  * Linux or macOS: `$ TESTCASE=<testcase_name> docker-compose up`
-  * Windows PowerShell: `> ($env:TESTCASE="<testcase_name>") -and (docker-compose up)`
+  * Linux or macOS: ``$ TESTCASE=<testcase_name> docker-compose up``
+  * Windows PowerShell: ``> ($env:TESTCASE="<testcase_name>") -and (docker-compose up)``
   * A couple notes:
-    * Replace `<testcase_name>` with the name of the test case you wish to deploy.
-    * The first time this command is run, the image `boptest_base` will be built. This takes about a minute. Subsequent usage will use the already-built image and deploy much faster.
-    * If you update your BOPTEST repository, use the command `docker rmi boptest_base` to remove the image so it can be re-built with the updated repository upon next deployment.
-    * `TESTCASE` is simply an environment variable. Consistent with use of docker-compose, you may also edit the value of this variable in the `.env` file and then use `docker-compose up`.
+    * Replace ``<testcase_name>`` with the name of the test case you wish to deploy.
+    * The first time this command is run, the image ``boptest_base`` will be built. This takes about a minute. Subsequent usage will use the already-built image and deploy much faster.
+    * If you update your BOPTEST repository, use the command ``docker rmi boptest_base`` to remove the image so it can be re-built with the updated repository upon next deployment.
+    * ``TESTCASE`` is simply an environment variable. Consistent with use of docker-compose, you may also edit the value of this variable in the ``.env`` file and then use ``docker-compose up``.
 
 4) In a separate process, use the test case API defined below to interact with the test case using your test controller.  Alternatively, view and run an example test controller as described below.
 5) Shutdown the test case by the command ``docker-compose down`` executed in the root directory of this repository

--- a/contributors.md
+++ b/contributors.md
@@ -4,6 +4,7 @@ Thank you to all who have provided guidance on the development of this software.
 
 - Javier Arroyo, KU Leuven
 - Kyle Benne, National Renewable Energy Laboratory
+- Dave Biagioni, National Renewable Energy Laboratory
 - David Blum, Lawrence Berkeley National Laboratory
 - Yan Chen, Pacific Northwest National Laboratory
 - Konstantin Filonenko, University of Southern Denmark

--- a/testcases/README.md
+++ b/testcases/README.md
@@ -2,7 +2,7 @@
 
 This directory contains test cases for BOPTEST.  A summary of available test cases is provided in the table below.  For more detail on a particular test case, go to ``/<testcase_dir_name>/docs``.
 
-| Test Case                                                  | Description                                   | Scenarios |
+| Test Case Name                                             | Description                                   | Scenarios |
 |------------------------------------------------------------|-----------------------------------------------|--------------------|
 | ``testcase1`` | Prototype test case for development purposes.  Single-zone R1C1 room model with sinusoidal ambient temperature and heater. |**Electricity Prices**: <br />``'constant'``, <br />``'dynamic'``, <br />``'highly_dynamic'``<br />**Time Periods**:<br />``'test_day'``|
 | ``testcase2``| Prototype test case for development purposes.  Based on the single-zone AHU model found in Modelica Buildings Library. |**Electricity Prices**: <br />``'constant'``, <br />``'dynamic'``, <br />``'highly_dynamic'``<br />**Time Periods**:<br />``'test_day'``|


### PR DESCRIPTION
Instructions for building and deploying a test case -- which say to define the `TESTCASE` env var as a directory rather than the testcase name -- currently fail:

```
$ TESTCASE=./testcases/testcase1/ docker-compose up
[+] Running 1/1
 ⠿ Container project1-boptest-boptest-1  Recreated                                             0.2s
Attaching to project1-boptest-boptest-1
project1-boptest-boptest-1  | Traceback (most recent call last):
project1-boptest-boptest-1  |   File "restapi.py", line 63, in <module>
project1-boptest-boptest-1  |     case = TestCase()
project1-boptest-boptest-1  |   File "/home/developer/testcase.py", line 49, in __init__
project1-boptest-boptest-1  |     self.data_manager.load_data_and_jsons()
project1-boptest-boptest-1  |   File "/home/developer/data/data_manager.py", line 374, in load_data_and_jsons
project1-boptest-boptest-1  |     z_fmu = zipfile.ZipFile(self.case.fmupath, 'r')
project1-boptest-boptest-1  |   File "/usr/lib/python2.7/zipfile.py", line 779, in __init__
project1-boptest-boptest-1  |     self.fp = open(file, modeDict[mode])
project1-boptest-boptest-1  | IOError: [Errno 21] Is a directory: 'models/wrapped.fmu'
project1-boptest-boptest-1 exited with code 1
```

But the [instructions in the user manual](https://ibpsa.github.io/project1-boptest/docs-userguide/getting_started.html#deploy-a-test-case) appear to work.  This PR simply updates the README with these modified steps (if this is indeed an error).