### PR TITLE
Issue450 split travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,21 @@ jobs:
   include:
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make test_all
+    script:
+      - cd testing && make build_jm_image && make build_boptest_image && make test_parser
+      - cd testing && make build_jm_image && make build_boptest_image && make test_data
+      - cd testing && make build_jm_image && make build_boptest_image && make test_forecast
+      - cd testing && make build_jm_image && make build_boptest_image && make test_kpis
+      - cd testing && make build_jm_image && make build_boptest_image && make test_readme_commands
+      - cd testing && make build_jm_image && make build_boptest_image && make test_testcase1
+      - cd testing && make build_jm_image && make build_boptest_image && make test_testcase2
+      - cd testing && make build_jm_image && make build_boptest_image && make test_testcase3
+      - cd testing && make build_jm_image && make build_boptest_image && make test_bestest_air
+      - cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic
+      - cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic_heat_pump
+      - cd testing && make build_jm_image && make build_boptest_image && make test_multizone_residential_hydronic
+      - cd testing && make build_jm_image && make build_boptest_image && make test_singlezone_commercial_hydronic
+      - cd testing && make build_jm_image && make build_boptest_image && make test_multizone_office_simple_air
   - python: 2.7
     install: pip install --upgrade pip && pip install pandas==0.24.2 numpy==1.16.6 matplotlib==2.1.1 requests==2.18.4
     script: cd testing && make test_python2

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,46 @@ jobs:
   include:
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script:
-      - cd testing && make build_jm_image && make build_boptest_image && make test_parser
-      - cd testing && make build_jm_image && make build_boptest_image && make test_data
-      - cd testing && make build_jm_image && make build_boptest_image && make test_forecast
-      - cd testing && make build_jm_image && make build_boptest_image && make test_kpis
-      - cd testing && make build_jm_image && make build_boptest_image && make test_readme_commands
-      - cd testing && make build_jm_image && make build_boptest_image && make test_testcase1
-      - cd testing && make build_jm_image && make build_boptest_image && make test_testcase2
-      - cd testing && make build_jm_image && make build_boptest_image && make test_testcase3
-      - cd testing && make build_jm_image && make build_boptest_image && make test_bestest_air
-      - cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic
-      - cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic_heat_pump
-      - cd testing && make build_jm_image && make build_boptest_image && make test_multizone_residential_hydronic
-      - cd testing && make build_jm_image && make build_boptest_image && make test_singlezone_commercial_hydronic
-      - cd testing && make build_jm_image && make build_boptest_image && make test_multizone_office_simple_air
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_parser
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_data
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_forecast
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_kpis
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_readme_commands
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase1
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase2
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase3
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_air
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic_heat_pump
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_residential_hydronic
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_singlezone_commercial_hydronic
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_office_simple_air
   - python: 2.7
     install: pip install --upgrade pip && pip install pandas==0.24.2 numpy==1.16.6 matplotlib==2.1.1 requests==2.18.4
     script: cd testing && make test_python2

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,46 +25,46 @@ jobs:
   include:
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_parser
+    script: cd testing && make build_jm_image && make test_parser
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_data
+    script: cd testing && make build_jm_image && make test_data
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_forecast
+    script: cd testing && make build_jm_image && make test_forecast
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_kpis
+    script: cd testing && make build_jm_image && make test_kpis
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_readme_commands
+    script: cd testing && make build_jm_image && make test_readme_commands
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase1
+    script: cd testing && make build_jm_image && make test_testcase1
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase2
+    script: cd testing && make build_jm_image && make test_testcase2
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase3
+    script: cd testing && make build_jm_image && make test_testcase3
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_air
+    script: cd testing && make build_jm_image && make test_bestest_air
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic
+    script: cd testing && make build_jm_image && make test_bestest_hydronic
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic_heat_pump
+    script: cd testing && make build_jm_image && make test_bestest_hydronic_heat_pump
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_residential_hydronic
+    script: cd testing && make build_jm_image && make test_multizone_residential_hydronic
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_singlezone_commercial_hydronic
+    script: cd testing && make build_jm_image && make test_singlezone_commercial_hydronic
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_office_simple_air
+    script: cd testing && make build_jm_image && make test_multizone_office_simple_air
   - python: 2.7
     install: pip install --upgrade pip && pip install pandas==0.24.2 numpy==1.16.6 matplotlib==2.1.1 requests==2.18.4
     script: cd testing && make test_python2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,7 @@ services:
   - docker
 
 env:
-  global:
-    - DOCKER_COMPOSE_VERSION=1.26.0
-  jobs:
-    - TEST=test_parser
-    - TEST=test_data
-    - TEST=test_forecast
-    - TEST=test_kpis
-    - TEST=test_readme_commands
-    - TEST=test_testcase1
-    - TEST=test_testcase2
-    - TEST=test_testcase3
-    - TEST=test_bestest_air
-    - TEST=test_bestest_hydronic
-    - TEST=test_bestest_hydronic_heat_pump
-    - TEST=test_multizone_residential_hydronic
-    - TEST=test_singlezone_commercial_hydronic
-    - TEST=test_multizone_office_simple_air
+  - DOCKER_COMPOSE_VERSION=1.26.0
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -41,7 +25,46 @@ jobs:
   include:
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make $TEST
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_parser
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_data
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_forecast
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_kpis
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_readme_commands
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase1
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase2
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase3
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_air
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic_heat_pump
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_residential_hydronic
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_singlezone_commercial_hydronic
+  - python: 3.9
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_office_simple_air
   - python: 2.7
     install: pip install --upgrade pip && pip install pandas==0.24.2 numpy==1.16.6 matplotlib==2.1.1 requests==2.18.4
     script: cd testing && make test_python2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,23 @@ services:
   - docker
 
 env:
-  - DOCKER_COMPOSE_VERSION=1.26.0
+  global:
+    - DOCKER_COMPOSE_VERSION=1.26.0
+  jobs:
+    - TEST=test_parser
+    - TEST=test_data
+    - TEST=test_forecast
+    - TEST=test_kpis
+    - TEST=test_readme_commands
+    - TEST=test_testcase1
+    - TEST=test_testcase2
+    - TEST=test_testcase3
+    - TEST=test_bestest_air
+    - TEST=test_bestest_hydronic
+    - TEST=test_bestest_hydronic_heat_pump
+    - TEST=test_multizone_residential_hydronic
+    - TEST=test_singlezone_commercial_hydronic
+    - TEST=test_multizone_office_simple_air
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -25,46 +41,7 @@ jobs:
   include:
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_parser
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_data
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_forecast
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_kpis
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_readme_commands
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase1
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase2
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_testcase3
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_air
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_bestest_hydronic_heat_pump
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_residential_hydronic
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_singlezone_commercial_hydronic
-  - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
-    script: cd testing && make build_jm_image && make build_boptest_image && make test_multizone_office_simple_air
+    script: cd testing && make build_jm_image && make build_boptest_image && make $TEST
   - python: 2.7
     install: pip install --upgrade pip && pip install pandas==0.24.2 numpy==1.16.6 matplotlib==2.1.1 requests==2.18.4
     script: cd testing && make test_python2

--- a/testing/makefile
+++ b/testing/makefile
@@ -73,6 +73,19 @@ generate_testcase_data:
 
 # Tests
 ###############################################################################
+
+# Generic test for all testcases except testcase1 and testcase2
+test_%:
+# Compile testcase model
+	make compile_testcase_model TESTCASE=$*
+# Build and deploy testcase image
+	cd .. && TESTCASE=$* docker-compose up -d
+	python sleep10.py
+# Run testcase tests
+	cd .. && python testing/test_$*.py
+# Stop testcase container
+	cd .. && docker-compose down
+
 test_testcase1:
 # Compile testcase model
 	make compile_testcase_model TESTCASE=testcase1
@@ -112,84 +125,6 @@ test_testcase2:
 	cd ../examples/julia && make remove-image Script=testcase2
 	cd ../examples/javascript && make remove-image Script=testcase2
 	cd ../examples/javascript && rm geckodriver
-
-test_bestest_air:
-# Compile testcase model
-	make compile_testcase_model TESTCASE=bestest_air
-# Build and deploy testcase image
-	cd .. && TESTCASE=bestest_air docker-compose up -d
-	python sleep10.py
-# Run testcase tests
-	cd .. && python testing/test_bestest_air.py
-# Stop testcase container
-	cd .. && TESTCASE=bestest_air docker-compose down
-
-test_testcase3:
-# Compile testcase model
-	make compile_testcase_model TESTCASE=testcase3
-# Build and deploy testcase image
-	cd .. && TESTCASE=testcase3 docker-compose up -d
-	python sleep10.py
-# Run testcase tests
-# Python and checks
-	cd .. && python testing/test_testcase3.py
-# Stop testcase container
-	cd .. && TESTCASE=testcase3 docker-compose down
-
-test_bestest_hydronic:
-# Compile testcase model
-	make compile_testcase_model TESTCASE=bestest_hydronic
-# Build and deploy testcase image
-	cd .. && TESTCASE=bestest_hydronic docker-compose up -d
-	python sleep10.py
-# Run testcase tests
-	cd .. && python testing/test_bestest_hydronic.py
-# Stop testcase container
-	cd .. && TESTCASE=bestest_hydronic docker-compose down
-
-test_bestest_hydronic_heat_pump:
-# Compile testcase model
-	make compile_testcase_model TESTCASE=bestest_hydronic_heat_pump
-# Build and deploy testcase image
-	cd .. && TESTCASE=bestest_hydronic_heat_pump docker-compose up -d
-	python sleep10.py
-# Run testcase tests
-	cd .. && python testing/test_bestest_hydronic_heat_pump.py
-# Stop testcase container
-	cd .. && TESTCASE=bestest_hydronic_heat_pump docker-compose down
-
-test_multizone_residential_hydronic:
-# Compile testcase model
-	make compile_testcase_model TESTCASE=multizone_residential_hydronic
-# Build and deploy testcase image
-	cd .. && TESTCASE=multizone_residential_hydronic docker-compose up -d
-	python sleep10.py && python sleep10.py
-# Run testcase tests
-	cd .. && python testing/test_multizone_residential_hydronic.py
-# Stop testcase container
-	cd .. && TESTCASE=multizone_residential_hydronic docker-compose down
-
-test_singlezone_commercial_hydronic:
-# Compile testcase model
-	make compile_testcase_model TESTCASE=singlezone_commercial_hydronic
-# Build and deploy testcase image
-	cd .. && TESTCASE=singlezone_commercial_hydronic docker-compose up -d
-	python sleep10.py && python sleep10.py
-# Run testcase tests
-	cd .. && python testing/test_singlezone_commercial_hydronic.py
-# Stop testcase container
-	cd .. && TESTCASE=singlezone_commercial_hydronic docker-compose down
-
-test_multizone_office_simple_air:
-# Compile testcase model
-	make compile_testcase_model TESTCASE=multizone_office_simple_air
-# Build and deploy testcase image
-	cd .. && TESTCASE=multizone_office_simple_air docker-compose up -d
-	python sleep10.py && python sleep10.py
-# Run testcase tests
-	cd .. && python testing/test_multizone_office_simple_air.py
-# Stop testcase container
-	cd .. && TESTCASE=multizone_office_simple_air docker-compose down
 
 test_parser:
 	make run_jm


### PR DESCRIPTION
This is for #450.  In particular, it splits each test into parallel jobs so as to avoid the travis job timeout error.  This replaces #452 and #453.