### PR TITLE
fix issue #540

### DIFF
--- a/kpis/kpi_calculator.py
+++ b/kpis/kpi_calculator.py
@@ -694,7 +694,7 @@ class KPI_Calculator(object):
         '''
 
         elapsed_control_time_ratio = self.case._get_elapsed_control_time_ratio()
-        time_rat = np.mean(elapsed_control_time_ratio)
+        time_rat = np.mean(elapsed_control_time_ratio) if len(elapsed_control_time_ratio) else None
 
         self.case.time_rat = time_rat
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -6,9 +6,10 @@ Released on xx/xx/xxxx.
 
 **The following changes are backwards-compatible and do not significantly change benchmark results:**
 
-- Update ``docs/tutorials/tutorial1_developer`` and ``docs/workshops/BS21Workshop_20210831``.  This is for This is for [#532](https://github.com/ibpsa/project1-boptest/issues/532).
+- Update ``docs/tutorials/tutorial1_developer`` and ``docs/workshops/BS21Workshop_20210831``.  This is for [#532](https://github.com/ibpsa/project1-boptest/issues/532).
 - In examples and unit test Python requests, use ``json`` attribute instead of ``data``.  This is for [#528](https://github.com/ibpsa/project1-boptest/issues/528).
 - In unit test checking fetching of single forecast variable, specify specific forecast point to check for each test case.  This is for [#529](https://github.com/ibpsa/project1-boptest/issues/529).
+- Update ``KPI_Calculator.get_computational_time_ratio`` to return ``None`` if no simulation steps have been processed. This is for [#540](https://github.com/ibpsa/project1-boptest/issues/540).
 
 
 ## BOPTEST v0.4.0


### PR DESCRIPTION
The issue #540 reports an invalid JSON format when a KPI indicator is requested at the beginning of a scenario. This occurs because the kpi_calculator.get_computational_time_ratio function returns an np.nan value when no time ratio is available. Since the Flask JSON encoder cannot convert np.nan to null, this results in an incorrect JSON format.

I propose to return an arbitrary zero value from get_computational_time_ratio if no data is available for computation. This fixes issue #540 with a very minor change.