### PR TITLE
Issue540 nan kpi

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -8,6 +8,7 @@ Thank you to all who have provided guidance on the development of this software.
 - David Blum, Lawrence Berkeley National Laboratory
 - Yan Chen, Pacific Northwest National Laboratory
 - Konstantin Filonenko, University of Southern Denmark
+- Gauthier-Clerc Francois, Pure Control
 - Valentin Gavan, ENGIE
 - Lieve Helsen, KU Leuven
 - Sen Huang, Pacific Northwest National Laboratory

--- a/kpis/kpi_calculator.py
+++ b/kpis/kpi_calculator.py
@@ -694,7 +694,7 @@ class KPI_Calculator(object):
         '''
 
         elapsed_control_time_ratio = self.case._get_elapsed_control_time_ratio()
-        time_rat = np.mean(elapsed_control_time_ratio)
+        time_rat = np.mean(elapsed_control_time_ratio) if len(elapsed_control_time_ratio) else None
 
         self.case.time_rat = time_rat
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -6,9 +6,10 @@ Released on xx/xx/xxxx.
 
 **The following changes are backwards-compatible and do not significantly change benchmark results:**
 
-- Update ``docs/tutorials/tutorial1_developer`` and ``docs/workshops/BS21Workshop_20210831``.  This is for This is for [#532](https://github.com/ibpsa/project1-boptest/issues/532).
+- Update ``docs/tutorials/tutorial1_developer`` and ``docs/workshops/BS21Workshop_20210831``.  This is for [#532](https://github.com/ibpsa/project1-boptest/issues/532).
 - In examples and unit test Python requests, use ``json`` attribute instead of ``data``.  This is for [#528](https://github.com/ibpsa/project1-boptest/issues/528).
 - In unit test checking fetching of single forecast variable, specify specific forecast point to check for each test case.  This is for [#529](https://github.com/ibpsa/project1-boptest/issues/529).
+- Update ``KPI_Calculator.get_computational_time_ratio`` to return ``None`` if no simulation steps have been processed. This is for [#540](https://github.com/ibpsa/project1-boptest/issues/540).
 
 
 ## BOPTEST v0.4.0


### PR DESCRIPTION
This is for #540.  In particular, it fixes the KPI calculator so that it returns a Python None object for the computational time ratio KPI instead of NaN if the test has not been advanced yet.

Verified using Mozilla Firefox browser for testcase2 after starting test case but not advancing at all, as exampled in #540 to demonstrate error:
<img width="418" alt="Screen Shot 2023-05-26 at 6 19 05 PM" src="https://github.com/ibpsa/project1-boptest/assets/19480999/1d83081b-edde-45ee-aec1-f95458336a59">


Unit tests should pass.

@Enderdead can you verify I updated ``contributors.md`` properly for you?  And thank you for the fix.