### PR TITLE
Pin Dockerfile image to `linux/x86_64`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/x86_64 ubuntu:20.04
 
 # Install required packages
 RUN 	apt-get update && \

--- a/contributors.md
+++ b/contributors.md
@@ -19,6 +19,7 @@ Thank you to all who have provided guidance on the development of this software.
 - Robert Lutes, Pacific Northwest National Laboratory
 - Kefei Mo, Pacific Northwest National Laboratory
 - Erik Paulson, Independent
+- Matt Robinson, University of Colorado - Boulder
 - Jermy Thomas, National Renewable Energy Laboratory
 - Christian Veje, University of Southern Denmark
 - Draguna Vrabie, Pacific Northwest National Laboratory

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -10,6 +10,7 @@ Released on xx/xx/xxxx.
 - Change JModelica docker container address  in ``testing/Dockerfile``. This is for [#590](https://github.com/ibpsa/project1-boptest/issues/590).
 - Specify the Python version (3.7) used for building the wrapper to execute the example JavaScript controllers in the unit test. This is for [#594](https://github.com/ibpsa/project1-boptest/issues/594).
 - Allow simulations and forecast to work across the end of the year to the next year. This is for [#239](https://github.com/ibpsa/project1-boptest/issues/239).
+- Pin base Docker image to ``linux/x86_64`` platform. This is for [#608](https://github.com/ibpsa/project1-boptest/issues/608).
 
 ## BOPTEST v0.5.0
 


### PR DESCRIPTION
Pin the base Docker image to `linux/x86_64` to enable the image to be used on Apple Silicon machines easily. This can be reverted when PyFMI is distributed to `linux/arm64` (https://github.com/modelon-community/PyFMI/issues/212).

Error for future reference:
```
$ docker-compose up
...
1.589 2024-01-22 16:51:21 (54.1 MB/s) - '/home/user/miniconda.sh' saved [74403966/74403966]
1.589
1.600 PREFIX=/home/user/miniconda
1.816 Unpacking payload ...
1.822 rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
1.822  /home/user/miniconda.sh: line 352:    38 Exit 141                extract_range $boundary1 $boundary2
1.822         39 Trace/breakpoint trap   | "$CONDA_EXEC" constructor --extract-tarball --prefix "$PREFIX"
------
failed to solve: process "/bin/sh -c cd $HOME && \twget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh -O $HOME/miniconda.sh && \t/bin/bash $HOME/miniconda.sh -b -p $HOME/miniconda && \t. miniconda/bin/activate && \tconda update -n base -c defaults conda && \tconda create --name pyfmi3 python=3.10 -y && \tconda activate pyfmi3 && \tconda install -c conda-forge pyfmi=2.11 -y && \tpip install flask-restful==0.3.9 werkzeug==2.2.3 && \tconda install pandas==1.5.3 flask_cors==3.0.10 matplotlib==3.7.1 requests==2.28.1" did not complete successfully: exit code: 133
```

The conda binary is already pinned to x86_64 so this just goes one step further with the base image:

https://github.com/ibpsa/project1-boptest/blob/358358566fc167e06c3957f5f79a6cef46812365/Dockerfile#L22

Fixes https://github.com/ibpsa/project1-boptest/issues/608.