### PR TITLE
Install and initialize Git LFS in `testing/Dockerfile`

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -12,6 +12,7 @@ Released on xx/xx/xxxx.
 - Allow simulations and forecast to work across the end of the year to the next year. This is for [#239](https://github.com/ibpsa/project1-boptest/issues/239).
 - Pin base Docker image to ``linux/x86_64`` platform. This is for [#608](https://github.com/ibpsa/project1-boptest/issues/608).
 - Correct typo in design documentation about connecting inputs to overwrite blocks in wrapper model. This is for [#601](https://github.com/ibpsa/project1-boptest/issues/601).
+- Correct Git LFS configuration in the ``testing/Dockerfile`` image used in tests and compilation. This should allow Spawn of EnergyPlus emulators to be compiled with the default compilation pipeline. This is for [#613](https://github.com/ibpsa/project1-boptest/issues/613).
 
 ## BOPTEST v0.5.0
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -12,7 +12,7 @@ Released on xx/xx/xxxx.
 - Allow simulations and forecast to work across the end of the year to the next year. This is for [#239](https://github.com/ibpsa/project1-boptest/issues/239).
 - Pin base Docker image to ``linux/x86_64`` platform. This is for [#608](https://github.com/ibpsa/project1-boptest/issues/608).
 - Correct typo in design documentation about connecting inputs to overwrite blocks in wrapper model. This is for [#601](https://github.com/ibpsa/project1-boptest/issues/601).
-- Correct Git LFS configuration in the ``testing/Dockerfile`` image used in tests and compilation. This should allow Spawn of EnergyPlus emulators to be compiled with the default compilation pipeline. This is for [#613](https://github.com/ibpsa/project1-boptest/issues/613).
+- Correct Git LFS configuration in the ``testing/Dockerfile`` image used in tests and compilation. This is for [#613](https://github.com/ibpsa/project1-boptest/issues/613).
 
 ## BOPTEST v0.5.0
 

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -4,6 +4,7 @@ USER root
 
 RUN apt-get update && \
     apt-get install -y git && \
+    apt-get install -y git-lfs && \
     apt-get install -y sudo
 
 USER developer
@@ -14,6 +15,7 @@ WORKDIR $HOME
 
 RUN mkdir $HOME/MODELICAPATH && mkdir git && \
     cd git && \
+    git lfs install && \
     git clone https://github.com/ibpsa/modelica-ibpsa.git && cd modelica-ibpsa && git checkout a8b77f6d2820c52a63cd5964db6db9913a5f669d && cd .. && \
     git clone https://github.com/open-ideas/IDEAS.git && \
     git clone https://github.com/lbl-srg/modelica-buildings.git && \


### PR DESCRIPTION
This addition allows me to compile a Modelica + Spawn of EnergyPlus emulator without issues. Otherwise, there are EnergyPlus related linker errors due to a file that is unlikely to be correct on the filesystem:

```
/usr/bin/ld:/home/developer/git/modelica-buildings/Buildings/Resources/Library/linux64/[libModelicaBuildingsEnergyPlus.so](http://libmodelicabuildingsenergyplus.so/): file format not recognized; treating as linker script
```

Fixes https://github.com/ibpsa/project1-boptest/issues/613.