### PR TITLE
Corrected typo in documentation for multizone_office_simple_air

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -12,6 +12,7 @@ Released on xx/xx/xxxx.
 - Allow simulations and forecast to work across the end of the year to the next year. This is for [#239](https://github.com/ibpsa/project1-boptest/issues/239).
 - Pin base Docker image to ``linux/x86_64`` platform. This is for [#608](https://github.com/ibpsa/project1-boptest/issues/608).
 - Correct typo in design documentation about connecting inputs to overwrite blocks in wrapper model. This is for [#601](https://github.com/ibpsa/project1-boptest/issues/601).
+- Correct typo in ``multizone_office_simple_air``, cooling setback temperature changed from 12 to 30. This is for [#605](https://github.com/ibpsa/project1-boptest/issues/605).
 
 ## BOPTEST v0.5.0
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -12,7 +12,7 @@ Released on xx/xx/xxxx.
 - Allow simulations and forecast to work across the end of the year to the next year. This is for [#239](https://github.com/ibpsa/project1-boptest/issues/239).
 - Pin base Docker image to ``linux/x86_64`` platform. This is for [#608](https://github.com/ibpsa/project1-boptest/issues/608).
 - Correct typo in design documentation about connecting inputs to overwrite blocks in wrapper model. This is for [#601](https://github.com/ibpsa/project1-boptest/issues/601).
-- Correct typo in ``multizone_office_simple_air``, cooling setback temperature changed from 12 to 30. This is for [#605](https://github.com/ibpsa/project1-boptest/issues/605).
+- Correct typo in documentation for ``multizone_office_simple_air``, cooling setback temperature changed from 12 to 30. This is for [#605](https://github.com/ibpsa/project1-boptest/issues/605).
 
 ## BOPTEST v0.5.0
 

--- a/testcases/multizone_office_simple_air/doc/index.html
+++ b/testcases/multizone_office_simple_air/doc/index.html
@@ -235,7 +235,7 @@ during unoccupied hours to maintain a cooling set point.
   <td>Unoccupied, night setup</td>
   <td>In unoccupied period, maximum TZon above unoccupied TZonCooSet.  Minimum state time is 30 min.</td>
   <td>12</td>
-  <td>12</td>
+  <td>30</td>
   <td>Enabled</td>
   <td>35</td>
   <td>Enabled</td>

--- a/testcases/multizone_office_simple_air/models/MultiZoneOfficeSimpleAir/TestCases/TestCase.mo
+++ b/testcases/multizone_office_simple_air/models/MultiZoneOfficeSimpleAir/TestCases/TestCase.mo
@@ -1,4 +1,4 @@
-﻿within MultiZoneOfficeSimpleAir.TestCases;
+within MultiZoneOfficeSimpleAir.TestCases;
 model TestCase
   "Variable air volume flow system with terminal reheat and five thermal zones based on Buildings.Examples.VAVReheat.ASHRAE2006"
   extends Modelica.Icons.Example;
@@ -314,7 +314,7 @@ during unoccupied hours to maintain a cooling set point.
   <td>Unoccupied, night setup</td>
   <td>In unoccupied period, maximum TZon above unoccupied TZonCooSet.  Minimum state time is 30 min.</td>
   <td>12</td>
-  <td>12</td>
+  <td>30</td>
   <td>Enabled</td>
   <td>35</td>
   <td>Enabled</td>
@@ -1141,6 +1141,11 @@ For reference, see https://www.eia.gov/electricity/state/illinois/
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 5, 2024, by Ettore Zanetti:<br/>
+Fixed typo in unoccupied cooling setpoint documentation.
+This is for BOPTEST <a href="https://github.com/ibpsa/project1-boptest/issues/605">issue #605</a>.
+</li>
 <li>
 August 25, 2022, by David Blum:<br/>
 Add forecast point documentation.

--- a/testcases/multizone_office_simple_air/models/MultiZoneOfficeSimpleAir/TestCases/TestCase.mo
+++ b/testcases/multizone_office_simple_air/models/MultiZoneOfficeSimpleAir/TestCases/TestCase.mo
@@ -1144,7 +1144,7 @@ For reference, see https://www.eia.gov/electricity/state/illinois/
 <li>
 February 5, 2024, by Ettore Zanetti:<br/>
 Fixed typo in unoccupied cooling setpoint documentation.
-This is for BOPTEST <a href="https://github.com/ibpsa/project1-boptest/issues/605">issue #605</a>.
+This is for BOPTEST <a href=\"https://github.com/ibpsa/project1-boptest/issues/605\">issue #605</a>.
 </li>
 <li>
 August 25, 2022, by David Blum:<br/>


### PR DESCRIPTION
This PR is to address issue #605, where is shown that a typo is present in the documentation for the cooling setpoint in unoccupied period. After verifying that it is indeed a just a typo, I updated the documentation. 