### PR TITLE
Issue634 python2 examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,3 @@ jobs:
   - python: 3.9
     install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
     script: cd testing && make build_jm_image && travis_wait 90 make test_multizone_residential_hydronic ARG="-s API"
-  - python: 2.7
-    install: pip install --upgrade pip && pip install pandas==0.24.2 numpy==1.16.6 matplotlib==2.1.1 requests==2.18.4
-    script: cd testing && make test_python2

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -4,6 +4,10 @@
 
 Released on xx/xx/xxxx.
 
+**The following changes are backwards-compatible and do not significantly change benchmark results:**
+
+- Remove support and unit testing of example python controllers using Python 2. This is for [#634](https://github.com/ibpsa/project1-boptest/issues/634).
+
 
 ## BOPTEST v0.6.0
 

--- a/testing/makefile
+++ b/testing/makefile
@@ -275,25 +275,6 @@ test_readme_commands:
 	curl http://127.0.0.1:5000/advance -d '{"oveTSetRooHea_u":293.15,"oveTSetRooHea_activate":1, "oveTSetRooCoo_activate":1,"oveTSetRooCoo_u":298.15}' -H "Content-Type: application/json"
 	cd .. && TESTCASE=testcase2 docker-compose down
 
-test_python2:
-# Test example controllers written in python run with python 2
-# Test testcase1
-	cd .. && TESTCASE=testcase1 docker-compose up -d
-	python sleep10.py
-	cd ../examples/python && python testcase1.py
-	cd ../examples/python && python testcase1_scenario.py
-	cd .. && TESTCASE=testcase1 docker-compose down
-# Test testcase2
-	cd .. && TESTCASE=testcase2 docker-compose up -d
-	python sleep10.py
-	cd ../examples/python && python testcase2.py
-	cd .. && TESTCASE=testcase2 docker-compose down
-# Test testcase3
-	cd .. && TESTCASE=testcase3 docker-compose up -d
-	python sleep10.py
-	cd ../examples/python && python testcase3.py
-	cd .. && TESTCASE=testcase32 docker-compose down
-
 ###############################################################################
 
 # Run all tests


### PR DESCRIPTION
This is for #634.  It drops support of testing example controllers with Python 2.