### PR TITLE
Issue655 numpy matplotlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,65 +28,65 @@ before_script:
 jobs:
   include:
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_parser
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_data
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_forecast
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_kpis
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1 rdflib==6.3.2 bacpypes==0.18.7
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1 rdflib==6.3.2 bacpypes==0.18.7
     script: cd testing && make build_jm_image && make test_bacnet
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_testcase
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_readme_commands
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_testcase1
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_testcase2
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_testcase3
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_bestest_air
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_bestest_hydronic
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_bestest_hydronic_heat_pump
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_singlezone_commercial_hydronic
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && make test_twozone_apartment_hydronic
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && travis_wait 90 make test_multizone_office_simple_air ARG="-s test_peak_heat_day,test_typical_heat_day"
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && travis_wait 90 make test_multizone_office_simple_air ARG="-s test_peak_cool_day,test_typical_cool_day,test_mix_day"
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && travis_wait 90 make test_multizone_office_simple_air ARG="-s API"
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && travis_wait 90 make test_multizone_residential_hydronic ARG="-s test_peak_heat_day,test_shoulder"
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && travis_wait 90 make test_multizone_residential_hydronic ARG="-s test_typical_heat_day,test_summer"
   - python: 3.9
-    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 matplotlib==3.3.4 requests==2.25.1
+    install: pip install --upgrade pip && pip install pandas==1.2.5 numpy==1.20.2 requests==2.25.1
     script: cd testing && make build_jm_image && travis_wait 90 make test_multizone_residential_hydronic ARG="-s API"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN 	cd $HOME && \
 	conda create --name pyfmi3 python=3.10 -y && \
 	conda activate pyfmi3 && \
 	conda install -c conda-forge pyfmi=2.12 -y && \
-	pip install flask-restful==0.3.9 werkzeug==2.2.3 && \
-	conda install pandas==1.5.3 flask_cors==3.0.10 matplotlib==3.7.1 requests==2.28.1
+	pip install flask-restful==0.3.9 werkzeug==2.2.3 pandas==1.5.3 flask_cors==3.0.10 scipy==1.13.0 matplotlib==3.7.1 requests==2.28.1
 
 WORKDIR $HOME
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -10,6 +10,7 @@ Released on xx/xx/xxxx.
 - Remove support and unit testing of example python controllers using Python 2. This is for [#634](https://github.com/ibpsa/project1-boptest/issues/634).
 - Add a warning message upon test case compilation in ``data/data_manager.py`` that is displayed if any of the weather variables in ``data/categories.json`` is not in ``<testcase_folder>/resources/weather.csv``. This is for [#500](https://github.com/ibpsa/project1-boptest/issues/500).
 - Remove matplotlib requirement from travis unit testing. This is for [#655](https://github.com/ibpsa/project1-boptest/issues/655).
+- Specify version of scipy to 1.13.0 in test case Dockerfile.  This is for [#657](https://github.com/ibpsa/project1-boptest/issues/657).
 
 ## BOPTEST v0.6.0
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -9,6 +9,7 @@ Released on xx/xx/xxxx.
 - Update pyfmi version from 2.11 to 2.12 and miniconda version from py310_23.1.0-1-Linux-x86_64 to py310_24.3.0-0-Linux-x86_64. This is for [#643](https://github.com/ibpsa/project1-boptest/issues/643).
 - Remove support and unit testing of example python controllers using Python 2. This is for [#634](https://github.com/ibpsa/project1-boptest/issues/634).
 - Add a warning message upon test case compilation in ``data/data_manager.py`` that is displayed if any of the weather variables in ``data/categories.json`` is not in ``<testcase_folder>/resources/weather.csv``. This is for [#500](https://github.com/ibpsa/project1-boptest/issues/500).
+- Remove matplotlib requirement from travis unit testing. This is for [#655](https://github.com/ibpsa/project1-boptest/issues/655).
 
 ## BOPTEST v0.6.0
 

--- a/testing/utilities.py
+++ b/testing/utilities.py
@@ -12,7 +12,6 @@ import numpy as np
 import json
 import pandas as pd
 import re
-import matplotlib.pyplot as plt
 from datetime import datetime
 
 
@@ -95,6 +94,8 @@ def compare_references(vars_timeseries = ['reaTRoo_y'],
         Name of the folder containing the new references.
 
     '''
+
+    import matplotlib.pyplot as plt
 
     dir_old = os.path.join(get_root_path(), 'testing', 'references', refs_old)
 


### PR DESCRIPTION
This is for https://github.com/ibpsa/project1-boptest/issues/655 and https://github.com/ibpsa/project1-boptest/issues/657:

-  moves matplotlib import to the one necessary function, which is only used locally and not in travis ci.
- removes installation of matplotlib in travis.
- specifies version of scipy to 1.13.0 in test case Dockerfile.

Ready to merge if tests pass.