### PR TITLE
issue677 Fix Doc Typo

### DIFF
--- a/testcases/multizone_office_simple_hydronic/doc/index.html
+++ b/testcases/multizone_office_simple_hydronic/doc/index.html
@@ -397,7 +397,7 @@ COP = -15.11 - 0.05 T<sub>supply</sub> + 0.125 T<sub>ambient</sub>
 </p>
 <p>
 where T<sub>supply</sub> and T<sub>ambient</sub> are in Kelvin.
-In essence, the chiller nominal EER (at 7 &#176;C supply and 35 &#176;C ambient temperature) is 2.5.
+In essence, the heat pump nominal COP (at 35 &#176;C supply and 7 &#176;C ambient temperature) is 4.5.
 </p>
 
 <p><b>Chiller</b> </p>
@@ -411,7 +411,7 @@ EER = -68.5 + 0.4 T<sub>supply</sub> - 4/30 T<sub>ambient</sub>
 </p>
 <p>
 where T<sub>supply</sub> and T<sub>ambient</sub> are in Kelvin.
-In essence, the heat pump nominal COP (at 35 &#176;C supply and 7 &#176;C ambient temperature) is 4.5.
+In essence, the chiller nominal EER (at 7 &#176;C supply and 35 &#176;C ambient temperature) is 2.5.
 </p>
 
 <p><b>Fluid movers</b> </p>

--- a/testcases/multizone_office_simple_hydronic/models/BuildingEmulators/BuildingSystem.mo
+++ b/testcases/multizone_office_simple_hydronic/models/BuildingEmulators/BuildingSystem.mo
@@ -496,7 +496,7 @@ COP = -15.11 - 0.05 T<sub>supply</sub> + 0.125 T<sub>ambient</sub>
 </p>
 <p>
 where T<sub>supply</sub> and T<sub>ambient</sub> are in Kelvin.
-In essence, the chiller nominal EER (at 7 &#176;C supply and 35 &#176;C ambient temperature) is 2.5.
+In essence, the heat pump nominal COP (at 35 &#176;C supply and 7 &#176;C ambient temperature) is 4.5.
 </p>
 
 <p><b>Chiller</b> </p>
@@ -510,7 +510,7 @@ EER = -68.5 + 0.4 T<sub>supply</sub> - 4/30 T<sub>ambient</sub>
 </p>
 <p>
 where T<sub>supply</sub> and T<sub>ambient</sub> are in Kelvin.
-In essence, the heat pump nominal COP (at 35 &#176;C supply and 7 &#176;C ambient temperature) is 4.5.
+In essence, the chiller nominal EER (at 7 &#176;C supply and 35 &#176;C ambient temperature) is 2.5.
 </p>
 
 <p><b>Fluid movers</b> </p>


### PR DESCRIPTION
This is for #677.  It fixes a typo in documentation for multizone_office_simple_hydronic.