### PR TITLE
Issue 794 examples update error handling

### DIFF
--- a/examples/python/interface.py
+++ b/examples/python/interface.py
@@ -93,18 +93,18 @@ def control_test(testcase_name, control_module='', start_time=0, warmup_period=0
             return response
         print("Unexpected error: {}".format(response.text))
         requests.put('{0}/stop/{1}'.format(url, testid))
-        print("Test case successfully stopped. Exiting...")
+        print("Test case successfully stopped. Exited with status code {}.".format(status))
         sys.exit()
 
-    # Wrap function in try/except to ensure the test case is correctly stopped if an error occurs
-    try:
+    # SETUP TEST
+    # -------------------------------------------------------------------------
+    # Set URL for testcase
+    url = 'http://127.0.0.1:80'
+    # Instantiate concrete controller (pid, pidTwoZones, sup, etc.)
+    controller = Controller(control_module, use_forecast)
 
-        # SETUP TEST
-        # -------------------------------------------------------------------------
-        # Set URL for testcase
-        url = 'http://127.0.0.1:80'
-        # Instantiate concrete controller (pid, pidTwoZones, sup, etc.)
-        controller = Controller(control_module, use_forecast)
+    # Wrap test case selection in try/except to correctly handle errors in the API
+    try:
 
         # GET TEST INFORMATION
         # -------------------------------------------------------------------------
@@ -112,6 +112,14 @@ def control_test(testcase_name, control_module='', start_time=0, warmup_period=0
         # Select test case
         testid = requests.post("{0}/testcases/{1}/select".format(url, testcase_name)).json()["testid"]
         print('TestID:\t\t\t\t{0}'.format(testid))
+
+    except Exception as e:
+        print('\n\nIncorrect selection of test case: {}. Exiting...'.format(e))
+        sys.exit()
+
+    # Wrap other API calls in try/except to correctly shut down running test case on error
+    try:
+
         # Retrieve testcase name from REST API
         name = check_response(requests.get('{0}/name/{1}'.format(url,testid)))
         print('Name:\t\t\t\t{0}'.format(name))

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -16,7 +16,7 @@ Released on xx/xx/xxxx.
 - Update Spawn version to ``light-0.4.3-7048a72798``, which is used in Modelica Buildings Library v9.1.1. This is for [#782](https://github.com/ibpsa/project1-boptest/issues/782).
 - Add actuator travel KPI calculation spec to design docs, method to ``kpis/kpi_calculator.py``, and signal parsing process in ``parsing/parser.py``. Requires additional updates to test cases before available for use. This is for [#639](https://github.com/ibpsa/project1-boptest/issues/639).
 - Update dashboard payload from ``/submit`` request to align with weather forecast uncertainty implementation. This is for [#721](https://github.com/ibpsa/project1-boptest/issues/721).
-- Add error handling to the Python examples which catches API call errors and own Python errors. This is for [#794](https://github.com/ibpsa/project1-boptest/issues/794).
+- Add error handling to the Python examples which catches API call errors and own Python errors by reporting the error and gracefully shutting down the test case. This is for [#794](https://github.com/ibpsa/project1-boptest/issues/794).
 - For the ``/results`` API, use object storage via s3/minio instead of Redis to transfer data from ``worker`` to ``web`` if the returned data package is larger than 1 MB. This is for [#732](https://github.com/ibpsa/project1-boptest/issues/732).
 
 **The following changes are not backwards compatible, but do not change benchmark results:**


### PR DESCRIPTION
This is for #794 

Added error handling in the Python examples. This catches API call errors and own python errors in the code. I also added a KeyBoardInterrupt statement, but this does not work when the API call is in progress, so sometimes it catches it, sometimes not.

This does not change anything about the working examples, as that code is all fine, the meaning is to impose a good habit on new users.

The `check_response` had to be included in the `control_test` function such that the `url` and `testid` attributes are correctly transferred in case an API call error must be handled.

The body of `control_test` has been wrapped in a try/except statement. I chose this option since then the attributes `url` and `testid` can be used correctly. This also did not require any changes for the individual example scripts.