### PR TITLE
Issue847 multizone residential hydronic docs

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -28,6 +28,7 @@ Released on xx/xx/xxxx.
 
 - Change port BOPTEST listens to on localhost from ``:80`` to ``:8000``. This is for [#822](https://github.com/ibpsa/project1-boptest/issues/822).
 - Change ``bacnet/BopTestProxy.py`` control step argument from ``simulation_step`` to ``control_step``. This is for [#830](https://github.com/ibpsa/project1-boptest/issues/830).
+- Fix description of overwrite block ``oveEmiPum`` for the ``multizone_residential_hydronic`` test case in the design documentation. This is for [#847](https://github.com/ibpsa/project1-boptest/issues/847).
 
 **The following changes are API-backwards-compatible, but significantly change benchmark results:**
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -28,7 +28,7 @@ Released on xx/xx/xxxx.
 
 - Change port BOPTEST listens to on localhost from ``:80`` to ``:8000``. This is for [#822](https://github.com/ibpsa/project1-boptest/issues/822).
 - Change ``bacnet/BopTestProxy.py`` control step argument from ``simulation_step`` to ``control_step``. This is for [#830](https://github.com/ibpsa/project1-boptest/issues/830).
-- Fix description of overwrite block ``oveEmiPum`` for the ``multizone_residential_hydronic`` test case in the design documentation. This is for [#847](https://github.com/ibpsa/project1-boptest/issues/847).
+- Fix configuration and description of overwrite block ``oveEmiPum`` for the ``multizone_residential_hydronic`` test case in the design documentation. This is for [#847](https://github.com/ibpsa/project1-boptest/issues/847).
 
 **The following changes are API-backwards-compatible, but significantly change benchmark results:**
 
@@ -37,7 +37,7 @@ Released on xx/xx/xxxx.
   - Use Modelica Buildings Library v12.1.0 and Modelica IDEAS Library v4.0.0 (respectively for whichever library is used in each test case), except ``multizone_office_complex_air`` and ``multizone_office_simple_hydronic`` for which library versions have not changed. This is for [#422](https://github.com/ibpsa/project1-boptest/issues/422).
   - Compile all test case FMUs in repository using Dymola 2025x with the Binary Model Export option, except for ``testcase1`` which is compiled using OpenModelica v1.26.8. This is for [#422](https://github.com/ibpsa/project1-boptest/issues/422).
   - See more details about changes to each test case Modelica model and effects on baseline KPIs to make all the above changes work and close additional issues in ``testcases/releasenotes-v1.0.0``.
-
+- Fixed the scaling of internal gains of ``Ro3`` for the ``multizone residential hydronic`` case, related to the updated building topology by [#834](https://github.com/ibpsa/project1-boptest/issues/834). The file ``dataFromModel.csv`` was updated accordingly. This is for [#847](https://github.com/ibpsa/project1-boptest/issues/847).
 
 ## BOPTEST v0.9.0
 

--- a/testcases/multizone_residential_hydronic/doc/MultiZoneResidentialHydronic.html
+++ b/testcases/multizone_residential_hydronic/doc/MultiZoneResidentialHydronic.html
@@ -352,7 +352,7 @@ The model inputs are:
 <code>oveEmiPum_activate</code> [1] [min=0, max=1]: Activation signal to overwrite input oveEmiPum_u where 1 activates, 0 deactivates (default value)
 </li>
 <li>
-<code>oveEmiPum_u</code> [1] [min=0.0, max=1.0]: Control signal to the circulation pump of the emission system
+<code>oveEmiPum_u</code> [kg/s] [min=0.0, max=0.25]: Mass flow rate prescribed to the circulation pump of the emission system
 </li>
 <li>
 <code>oveMixValSup_activate</code> [1] [min=0, max=1]: Activation signal to overwrite input oveMixValSup_u where 1 activates, 0 deactivates (default value)

--- a/testcases/multizone_residential_hydronic/models/MultiZoneResidentialHydronic/GenerateData.mo
+++ b/testcases/multizone_residential_hydronic/models/MultiZoneResidentialHydronic/GenerateData.mo
@@ -9,7 +9,7 @@ model GenerateData
   parameter Modelica.Units.SI.Area S_Chambre1 = 11.16;
 
   // Room 2
-  parameter Modelica.Units.SI.Area S_Chambre2 = 9.85;
+  parameter Modelica.Units.SI.Area S_Chambre2 = 10.8;
 
   // Room 3
   parameter Modelica.Units.SI.Area S_Chambre3 = 14.28;

--- a/testcases/multizone_residential_hydronic/models/MultiZoneResidentialHydronic/TestCase.mo
+++ b/testcases/multizone_residential_hydronic/models/MultiZoneResidentialHydronic/TestCase.mo
@@ -1373,10 +1373,10 @@ public
         origin={-113,-119})));
   Buildings.Utilities.IO.SignalExchange.Overwrite oveEmiPum(u(
       min=0,
-      max=1,
-      unit="1"), description=
-        "Control signal to the circulation pump of the emission system")
-    "Overwrite the control signal to the circulation pump of the emission system"
+      max=mBoi_flow_nominal,
+      unit="kg/s"), description=
+        "Mass flow rate prescribed to the circulation pump of the emission system")
+    "Overwrite the mass flow rate prescribed to the circulation pump of the emission system"
     annotation (Placement(transformation(
         extent={{-3,-3},{3,3}},
         rotation=0,
@@ -2644,7 +2644,7 @@ The model inputs are:
 <code>oveEmiPum_activate</code> [1] [min=0, max=1]: Activation signal to overwrite input oveEmiPum_u where 1 activates, 0 deactivates (default value)
 </li>
 <li>
-<code>oveEmiPum_u</code> [1] [min=0.0, max=1.0]: Control signal to the circulation pump of the emission system
+<code>oveEmiPum_u</code> [kg/s] [min=0.0, max=0.25]: Mass flow rate prescribed to the circulation pump of the emission system
 </li>
 <li>
 <code>oveMixValSup_activate</code> [1] [min=0, max=1]: Activation signal to overwrite input oveMixValSup_u where 1 activates, 0 deactivates (default value)


### PR DESCRIPTION
This is for #847 

1) Fixed specification of overwrite block in [the modelica file](https://github.com/ibpsa/project1-boptest/blob/7c3c9035c67d2d6adcfcb865bec7860038c4a9d5/testcases/multizone_residential_hydronic/models/MultiZoneResidentialHydronic/TestCase.mo) and corresponding documentation, both in the same.mo file and the [.html file](https://github.com/ibpsa/project1-boptest/blob/7c3c9035c67d2d6adcfcb865bec7860038c4a9d5/testcases/multizone_residential_hydronic/doc/MultiZoneResidentialHydronic.html).

2) Discovered another small bug related to a previous issue #834 which was already merged in PR #835. The file [GenerateData.mo](https://github.com/ibpsa/project1-boptest/blob/7c3c9035c67d2d6adcfcb865bec7860038c4a9d5/testcases/multizone_residential_hydronic/models/MultiZoneResidentialHydronic/GenerateData.mo) still contained an unupdated surface for Ro3, which has an effect on the internal gains in the testcase.